### PR TITLE
Fix the state end point in the Arduino sketch

### DIFF
--- a/ESP8266-Lamp.ino
+++ b/ESP8266-Lamp.ino
@@ -9,7 +9,7 @@ ESP8266WebServer server(80);
 
 // Global Variables
 const int relay = 2; // Pin D4 on my NodeMCU
-int curstate = 1;
+int curstate = 0;
 
 /*
 *  Handle Relay State Change
@@ -52,7 +52,7 @@ void setup(void) {
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP());
   // And as regular external functions:
-  server.on("/state", handle_state);
+  server.on("/status", handle_state);
   server.on("/relay", handle_relay);
 
   // Start the server


### PR DESCRIPTION
The problem - The switch always reported as OFF when
you open the Home app.

- Make the server listen to '/status' instead of '/state'. This is
  because the McuLampAccessory sends requests to /status to get
  the state.
- Set the initial state to 0. We don't want the switch to be ON on
  initialization.